### PR TITLE
Override default templates by ciinabox folder one

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rake'
 require 'yaml'
 require 'erb'
 require 'fileutils'
+require 'pathname'
 require "net/http"
 
 namespace :ciinabox do
@@ -31,6 +32,10 @@ namespace :ciinabox do
 
   if File.exist?("#{ciinaboxes_dir}/#{ciinabox_name}/templates")
     templates2 = Dir["#{ciinaboxes_dir}/#{ciinabox_name}/templates/**/*.rb"]
+
+    ## we want to exclude overridden templates
+    templatesLocalFileNames = templates2.collect { |templateFile| File.basename(templateFile)}
+    templates = templates.select { |templateFile| not templatesLocalFileNames.include? File.basename(templateFile)}
     templates = templates + templates2
   end
 


### PR DESCRIPTION
If we have `ecs-cluster.rb` file both in `templates/ecs-cluster.rb` and in `$CIINABOXES_DIR/$CIINABOX/templates/ecs-cluster.rb` system will render both templates in same output file `output/ecs-cluster.json` - having 50% chance for resulting template to be corrupt - in case system template is larger in bytes than ciinabox one. 

Fix pushed makes sure that if we are overriding system template in ciinabox folder, system one won't be rendered at all. 