### PR TITLE
Support for lambdas

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,15 +50,14 @@ namespace :ciinabox do
   end
 
   CfnDsl::RakeTask.new do |t|
+    extras = [[:yaml,'config/default_params.yml']]
+    (Dir["#{ciinaboxes_dir}/#{ciinabox_name}/config/*.yml"].map { |f| [:yaml,f]}).each {|c| extras<<c}
+    extras << [:ruby,'ext/helper.rb']
+
     t.cfndsl_opts = {
       verbose: true,
       files: files,
-      extras: [
-        [ :yaml, "config/default_params.yml" ],
-        [ :yaml, "#{ciinaboxes_dir}/#{ciinabox_name}/config/params.yml" ],
-        [ :yaml, "#{ciinaboxes_dir}/#{ciinabox_name}/config/services.yml" ],
-        [ :ruby, 'ext/helper.rb']
-      ]
+      extras: extras
     }
   end
 

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -54,6 +54,9 @@ vpc:
 ecs:
   SubnetOctetA: "2"
   SubnetOctetB: "3"
+lambdaSubnets:
+  SubnetOctetA: "4"
+  SubnetOctetB: "5"
 
 #ciinabox environment config
 Mappings:

--- a/ext/config/managed_policies.yml
+++ b/ext/config/managed_policies.yml
@@ -1,0 +1,125 @@
+ec2-describe:
+  action:
+    - ec2:Describe*
+    - autoscaling:Describe*
+    - elasticloadbalancing:Describe*
+
+cloudwatch-logs:
+  action:
+    - logs:CreateLogGroup
+    - logs:CreateLogStream
+    - logs:PutLogEvents
+    - logs:DescribeLogStreams
+    - logs:DescribeLogGroups
+  resource:
+    - arn:aws:logs:*:*:*
+
+cloudwatch-monitoring:
+  action:
+    - cloudwatch:PutMetricData
+    - cloudwatch:GetMetricStatistics
+    - cloudwatch:ListMetrics
+
+s3-list-buckets:
+  action:
+    - s3:ListAllMyBuckets
+    - s3:ListBucket
+
+s3-chef-ro:
+  action:
+    - s3:Get*
+    - s3:List*
+  resource:
+    - arn:aws:s3:::%{source_bucket}/chef
+    - arn:aws:s3:::%{source_bucket}/chef/*
+
+s3-codedeploy-ro:
+  action:
+    - s3:Get*
+    - s3:List*
+  resource:
+    - arn:aws:s3:::%{source_bucket}/codedeploy
+    - arn:aws:s3:::%{source_bucket}/codedeploy/*
+
+ecs-service-role:
+  action:
+    - ecs:CreateCluster
+    - ecs:DeregisterContainerInstance
+    - ecs:DiscoverPollEndpoint
+    - ecs:Poll
+    - ecs:RegisterContainerInstance
+    - ecs:StartTelemetrySession
+    - ecs:Submit*
+    - ec2:AuthorizeSecurityGroupIngress
+    - ec2:Describe*
+    - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+    - elasticloadbalancing:Describe*
+    - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+    - autoscaling:Describe*
+
+ecr-pull-images:
+  action:
+    - ecr:BatchCheckLayerAvailability
+    - ecr:BatchGetImage
+    - ecr:Get*
+    - ecr:List*
+
+attach-ebs-volume:
+  action:
+    - ec2:DescribeVolumes
+    - ec2:AttachVolume
+    - ec2:DetachVolume
+
+attach-network-interface:
+  action:
+    - ec2:DescribeNetworkInterfaces
+    - ec2:AttachNetworkInterface
+    - ec2:DetachNetworkInterface
+
+associate-address:
+  action:
+    - ec2:AssociateAddress
+
+ssm:
+  action:
+    - ssm:DescribeAssociation
+    - ssm:GetDeployablePatchSnapshotForInstance
+    - ssm:GetDocument
+    - ssm:GetParameters
+    - ssm:ListAssociations
+    - ssm:ListInstanceAssociations
+    - ssm:PutInventory
+    - ssm:UpdateAssociationStatus
+    - ssm:UpdateInstanceAssociationStatus
+    - ssm:UpdateInstanceInformation
+
+ec2messages:
+  action:
+    - ec2messages:AcknowledgeMessage
+    - ec2messages:DeleteMessage
+    - ec2messages:FailMessage
+    - ec2messages:GetEndpoint
+    - ec2messages:GetMessages
+    - ec2messages:SendReply
+
+s3-secrets-ro:
+  action:
+    - s3:Get*
+    - s3:List*
+  resource:
+    - Fn::Join:
+      - ""
+      -
+        - 'arn:aws:s3:::'
+        - Fn::FindInMap:
+          - 'Secrets'
+          - Ref: 'EnvironmentType'
+          - 'bucket'
+        - '/'
+        - Fn::FindInMap:
+          - 'Secrets'
+          - Ref: 'EnvironmentType'
+          - 'key'
+        - '/'
+        - Ref: "EnvironmentName"
+        - '/*'

--- a/ext/policies.rb
+++ b/ext/policies.rb
@@ -1,0 +1,46 @@
+require 'yaml'
+
+module Configs
+  class << self; attr_accessor :managed_policies, :all end
+  @managed_policies = YAML.load(File.read('ext/config/managed_policies.yml'))
+  @all = Hash.new.tap { |h| Dir['config/*.yml'].each { |yml| h.merge!(YAML.load(File.open(yml))) }}
+end
+
+class Policies
+
+  def initialize
+    @policy_array = Array.new
+    @config = Configs.all
+    @policies = (@config.key?('custom_policies') ? Configs.managed_policies.merge(@config['custom_policies']) : Configs.managed_policies)
+  end
+
+  def get_policies(group = nil)
+    create_policies(@config['default_policies']) if @config.key?('default_policies')
+    create_policies(@config['group_policies'][group]) unless group.nil?
+    return @policy_array
+  end
+
+  def create_policies(policies)
+    policies.each do |policy|
+      raise "ERROR: #{policy} policy doesn't exist in the managed policies or as a custom policy" if !@policies.key?(policy)
+      resource = (@policies[policy].key?('resource') ? gsub_yml(@policies[policy]['resource']) : ["*"])
+      @policy_array << { PolicyName: policy, PolicyDocument: { Statement: [ { Effect:"Allow", Action: @policies[policy]['action'], Resource: resource }]} }
+    end
+    return @policy_array
+  end
+
+  # replaces %{variables} in the yml
+  def gsub_yml(resource)
+    replaced = []
+    resource.each { |r|
+      if r.is_a? String
+        replaced << r.gsub('%{source_bucket}', @config['source_bucket'])
+      else
+        replaced << r
+      end
+    }
+
+    return replaced
+  end
+
+end

--- a/templates/ciinabox.rb
+++ b/templates/ciinabox.rb
@@ -1,3 +1,5 @@
+require_relative '../ext/policies'
+
 CloudFormation do
 
   # Template metadata
@@ -68,6 +70,7 @@ CloudFormation do
   #e.g CIINABOXES_DIR/CIINABOX/templates/x.rb
   #for f in foreign templates do:
   #  new stack
+
   if defined? extra_stacks
     extra_stacks.each do | stack, details |
 
@@ -128,5 +131,6 @@ CloudFormation do
   Output("ECSInstanceProfile") {
     Value(FnGetAtt('ECSStack', 'Outputs.ECSInstanceProfile'))
   }
+
 
 end

--- a/templates/lambdas.rb
+++ b/templates/lambdas.rb
@@ -1,0 +1,121 @@
+require 'cfndsl'
+
+class Lambdas
+
+  def initialize
+
+  end
+
+  def create_stack(ciinabox_name, lambdas, lambdaSubnets, availability_zones, azId,
+      mappings,
+      ciinabox_version)
+
+    ciinaboxes_dir = ENV['CIINABOXES_DIR'] || 'ciinaboxes'
+
+    CloudFormation do
+
+      # Template metadata
+      AWSTemplateFormatVersion "2010-09-09"
+      Description "ciinabox - Lambda Functions -v #{ciinabox_version}"
+
+      # Parameters
+      Parameter("EnvironmentType") { Type 'String' }
+      Parameter("EnvironmentName") { Type 'String' }
+      Parameter("VPC") { Type 'String' }
+
+      # Route Tables
+      Parameter("RouteTablePrivateA") { Type 'String' }
+      Parameter("RouteTablePrivateB") { Type 'String' }
+
+      # Public Subnets
+      Parameter("SubnetPublicA") { Type 'String' }
+      Parameter("SubnetPublicB") { Type 'String' }
+
+      # Security Groups
+      Parameter("SecurityGroupBackplane") { Type 'String' }
+      Parameter("SecurityGroupOps") { Type 'String' }
+      Parameter("SecurityGroupDev") { Type 'String' }
+
+      Mapping('EnvironmentType', mappings['EnvironmentType'])
+
+      ## Subnets for Lambdas
+      availability_zones.each do |az|
+        Resource("SubnetPrivate#{az}") {
+          Type 'AWS::EC2::Subnet'
+          Property('VpcId', Ref('VPC'))
+          Property('CidrBlock', FnJoin("", [FnFindInMap('EnvironmentType', 'ciinabox', 'NetworkPrefix'), ".", FnFindInMap('EnvironmentType', 'ciinabox', 'StackOctet'), ".", lambdaSubnets["SubnetOctet#{az}"], ".0/", FnFindInMap('EnvironmentType', 'ciinabox', 'SubnetMask')]))
+          Property('AvailabilityZone', FnSelect(azId[az], FnGetAZs(Ref("AWS::Region"))))
+          Property('Tags', [{ Key: 'Name', Value: "ciinabox-lambda-private-#{az}" }])
+        }
+      end
+
+      lambdas['roles'].each do |lambda_role, role_config|
+        Resource("LambdaRole#{lambda_role}") {
+          Type 'AWS::IAM::Role'
+          Property('AssumeRolePolicyDocument', {
+              Statement: [
+                  Effect: 'Allow',
+                  Principal: { Service: ['lambda.amazonaws.com'] },
+                  Action: ['sts:AssumeRole']
+              ]
+          })
+          Property('Path', '/')
+          Property('Policies', Policies.new.create_policies(role_config['policies_inline']))
+
+          if (role_config['policies_managed'] != nil)
+            Property('ManagedPolicyArns', role_config['policies_managed'])
+          end
+        }
+      end
+
+
+      lambdas['functions'].each do |name, lambda_config|
+        timeout = lambda_config['timeout'] != nil ? lambda_config['timeout'] : 10
+        memory = lambda_config['memory'] != nil ? lambda_config['memory'] : 128
+        code = IO.read("#{ciinaboxes_dir}/#{ciinabox_name}/#{lambda_config['code']}")
+        environment = lambda_config['environment'] != nil ? lambda_config['environment'] : {}
+        Resource(name) do
+          Type 'AWS::Lambda::Function'
+          Property('Code', {
+              ZipFile: code
+          })
+          Property('Environment', {
+              Variables: Hash[environment.collect { |k, v| [k.upcase, v] }]
+          })
+          Property('Handler', 'index.handler')
+          Property('MemorySize', memory)
+          Property('Role', FnGetAtt("LambdaRole#{lambda_config['role']}", 'Arn'))
+          Property('Runtime', lambda_config['runtime'])
+          Property('Timeout', timeout)
+          if (lambda_config['vpc'] != nil && lambda_config['vpc'])
+            Property('VpcConfig', {
+                SubnetIds: availability_zones.collect { |az| Ref("SubnetPrivate#{az}") },
+                SecurityGroupIds: [Ref('SecurityGroupBackplane')]
+            })
+          end
+
+          if(lambda_config['named'] != nil && lambda_config['named'])
+            Property('FunctionName',name)
+          end
+
+        end
+
+        Output("Function#{name}") {
+          Value(Ref(name))
+        }
+
+      end
+
+    end
+  end
+
+end
+
+def create_stack_lambdas()
+
+end
+
+if defined? lambdas
+  Lambdas.new.create_stack(ciinabox_name, lambdas, lambdaSubnets, availability_zones, azId,Mappings, ciinabox_version)
+end
+


### PR DESCRIPTION
Example usage:
1) add extra stack in ciinabox configuration

```
extra_stacks:
lambdas:
    outputs:
      - FunctionScheduledEnvironmentCreate
```

2) define lambda functions and their respective roles

```

lambdas:
  roles:
    default:
      policies_managed:
        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'
      policies_inline:
        - cloudwatch-logs

  functions:
    ScheduledEnvironmentCreate:      # Key is function name at same time (if named:true, generated by CLoud Formation otherwise
      role: default                                   # IAM Role, must be defined  and match one of the keys in roles section
      code: templates/lambda/scheduled_environment_create.js   # Code file location, relative to ciinabox root
      runtime: nodejs4.3                        #  Code Runtime
      vpc: true                                        # Wheter to run within ciinabox VPC or not
      named: true                                   # If named, Lambda Function wil have fixed name
      environment:                                 # Environment variables defined here
        key1: value1 
```
