### PR TITLE
introduce volatile jenkins slave

### DIFF
--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -29,7 +29,7 @@ devAccess:
 # Upload a default ssl cert to AWS to be used by default to ciinabox service ELBs
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
-#add if you want jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
+#add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
 #volatile_jenkins_slave: true
 
 #add if you want ecs docker volume != 22GB - must be > 22

--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -29,8 +29,8 @@ devAccess:
 # Upload a default ssl cert to AWS to be used by default to ciinabox service ELBs
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
-#add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
-volatile_jenkins_slave: true
+#set this to false to use volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
+mount_jenkins_slave: true
 
 #add if you want ecs docker volume != 22GB - must be > 22
 #ecs_docker_volume_size: 100

--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -30,7 +30,7 @@ devAccess:
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
 #add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
-#volatile_jenkins_slave: true
+volatile_jenkins_slave: true
 
 #add if you want ecs docker volume != 22GB - must be > 22
 #ecs_docker_volume_size: 100

--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -29,8 +29,8 @@ devAccess:
 # Upload a default ssl cert to AWS to be used by default to ciinabox service ELBs
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
-#set this to false to use volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
-mount_jenkins_slave: true
+#add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
+#volatile_jenkins_slave: true
 
 #add if you want ecs docker volume != 22GB - must be > 22
 #ecs_docker_volume_size: 100

--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -29,6 +29,9 @@ devAccess:
 # Upload a default ssl cert to AWS to be used by default to ciinabox service ELBs
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
+#add if you want jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind from host
+#volatile_jenkins_slave: true
+
 #add if you want ecs docker volume != 22GB - must be > 22
 #ecs_docker_volume_size: 100
 

--- a/config/ciinabox_params.yml
+++ b/config/ciinabox_params.yml
@@ -29,7 +29,7 @@ devAccess:
 # Upload a default ssl cert to AWS to be used by default to ciinabox service ELBs
 default_ssl_cert_id: "arn:aws:iam::<%= ciinabox_aws_account %>:server-certificate/ciinabox"
 
-#add if you want jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind from host
+#add if you want jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
 #volatile_jenkins_slave: true
 
 #add if you want ecs docker volume != 22GB - must be > 22

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -297,7 +297,7 @@ CloudFormation {
       "service docker stop\n",
       "service docker start\n",
       "start ecs\n",
-      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(defined? mount_jenkins_slave and mount_jenkins_slave)? ' -v /data/jenkins-dind/:/var/lib/docker ' : ' '}base2/ciinabox-dind-slave\n",
+      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(defined? volatile_jenkins_slave and volatile_jenkins_slave)? ' ' : ' -v /data/jenkins-dind/:/var/lib/docker '}base2/ciinabox-dind-slave\n",
       "echo 'done!!!!'\n"
     ]))
   }

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -297,7 +297,7 @@ CloudFormation {
       "service docker stop\n",
       "service docker start\n",
       "start ecs\n",
-      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(not defined? volatile_jenkins_slave or not volatile_jenkins_slave)? ' ': ' -v /data/jenkins-dind/:/var/lib/docker '}base2/ciinabox-dind-slave\n",
+      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(defined? mount_jenkins_slave and mount_jenkins_slave)? ' -v /data/jenkins-dind/:/var/lib/docker ' : ' '}base2/ciinabox-dind-slave\n",
       "echo 'done!!!!'\n"
     ]))
   }

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -297,7 +297,7 @@ CloudFormation {
       "service docker stop\n",
       "service docker start\n",
       "start ecs\n",
-      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(not defined? volatile_jenkins_slave or not volatile_jenkins_slave)? '': ' -v /data/jenkins-dind/:/var/lib/docker '}base2/ciinabox-dind-slave\n",
+      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(not defined? volatile_jenkins_slave or not volatile_jenkins_slave)? ' ': ' -v /data/jenkins-dind/:/var/lib/docker '}base2/ciinabox-dind-slave\n",
       "echo 'done!!!!'\n"
     ]))
   }

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -297,7 +297,7 @@ CloudFormation {
       "service docker stop\n",
       "service docker start\n",
       "start ecs\n",
-      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22 -v /data/jenkins-dind/:/var/lib/docker base2/ciinabox-dind-slave\n",
+      "docker run --name jenkins-docker-slave --privileged=true -d -e PORT=4444 -p 4444:4444 -p 2223:22#{(not defined? volatile_jenkins_slave or not volatile_jenkins_slave)? '': ' -v /data/jenkins-dind/:/var/lib/docker '}base2/ciinabox-dind-slave\n",
       "echo 'done!!!!'\n"
     ]))
   }


### PR DESCRIPTION
# Overview
introduce the ability to ensure jenkins slave have a clean works space when recreated

## Details
when `volatile_jenkins_slave: true` , jenkins-slave's `/var/lib/docker` will not be mounted out from the hosts (`/data/jenkins-dind`), by default jenkins-slave's `/var/lib/docker` is always mounted out from `/data/jenkins-dind`