### PR TITLE
Fix for http://api.ipify.org/ instead of https://api.ipify.org/ and r…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -489,7 +489,7 @@ namespace :ciinabox do
   end
 
   def get_my_public_ip_address
-    Net::HTTP.get(URI("https://api.ipify.org"))
+    Net::HTTP.get(URI("http://api.ipify.org"))
   end
 
   def write_config_tmp_file(config)

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -230,7 +230,7 @@ CloudFormation {
     Roles [ Ref('Role') ]
   }
 
-  Volume(volume_name) {
+  EC2_Volume(volume_name) {
     DeletionPolicy 'Snapshot'
     Size volume_size
     VolumeType 'gp2'


### PR DESCRIPTION
…enaming volume to EC2_Volume for refacturing done in latest cfndsl for ecs-cluster.rb