### PR TITLE
Allow NAT connections to cluster

### DIFF
--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -102,6 +102,10 @@ ecs_ami:
 webHooks:
   - 192.30.252.0/22 #github
 
+# if set to true, security group allowing connections from NAT gateway will be assigned to
+# ecs cluster (useful for windows jenkins slaves)
+allow_nat_connections: false
+
 #extra_stacks:
 #  elk:
 #    #define template name? - optional
@@ -111,3 +115,4 @@ webHooks:
 #      CertName: x
 #      StackOctetA: 11
 #      StackOctetB: 12
+

--- a/templates/ciinabox.rb
+++ b/templates/ciinabox.rb
@@ -29,7 +29,8 @@ CloudFormation do
       RouteTablePrivateB: FnGetAtt('VPCStack', 'Outputs.RouteTablePrivateB'),
       SubnetPublicA: FnGetAtt('VPCStack', 'Outputs.SubnetPublicA'),
       SubnetPublicB: FnGetAtt('VPCStack', 'Outputs.SubnetPublicB'),
-      SecurityGroupBackplane: FnGetAtt('VPCStack', 'Outputs.SecurityGroupBackplane')
+      SecurityGroupBackplane: FnGetAtt('VPCStack', 'Outputs.SecurityGroupBackplane'),
+      SecurityGroupNatGateway: FnGetAtt('VPCStack', 'Outputs.SecurityGroupNatGateway')
     })
   }
 

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -24,6 +24,8 @@ CloudFormation {
   Parameter("SubnetPublicA"){ Type 'String' }
   Parameter("SubnetPublicB"){ Type 'String' }
   Parameter("SecurityGroupBackplane"){ Type 'String' }
+  Parameter('SecurityGroupNatGateway'){ Type 'String' }
+
 
   # Global mappings
   Mapping('EnvironmentType', Mappings['EnvironmentType'])
@@ -266,11 +268,13 @@ CloudFormation {
     }
   end
 
+  ecs_sgs = (defined? allow_nat_connections and allow_nat_connections) ? [ Ref('SecurityGroupBackplane'),Ref('SecurityGroupNatGateway') ]  : [ Ref('SecurityGroupBackplane') ]
+
   LaunchConfiguration( :LaunchConfig ) {
     ImageId FnFindInMap('ecsAMI',Ref('AWS::Region'),'ami')
     IamInstanceProfile Ref('InstanceProfile')
     KeyName FnFindInMap('EnvironmentType','ciinabox','KeyName')
-    SecurityGroups [ Ref('SecurityGroupBackplane') ]
+    SecurityGroups ecs_sgs
     InstanceType FnFindInMap('EnvironmentType','ciinabox','ECSInstanceType')
     if not ecs_block_device_mapping.empty?
       Property("BlockDeviceMappings", ecs_block_device_mapping)


### PR DESCRIPTION
Allow TCP connections to cluster from NAT gateway (optionally). Key used is 

```
# if set to true, security group allowing connections from NAT gateway will be assigned to
# ecs cluster (useful for windows jenkins slaves)
allow_nat_connections: true
```