### PR TITLE
Custom IAM role for CIINABOX cluster

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,8 +106,14 @@ namespace :ciinabox do
     stack_name = get_input("Enter the name of created Cloud Formation stack [ciinabox]:")
     stack_name = 'ciinabox' if(stack_name.strip == '')
 
-    include_dood_slave = yesno("Include docker-outside-of-docker slave?", true)
-    include_dind_slave = yesno("Include docker-in-docker slave?", true)
+    include_dood_slave = yesno("Include docker-outside-of-docker slave", true)
+    include_dind_slave = yesno("Include docker-in-docker slave", true)
+
+    use_iam_role = yesno("Use existing role for CIINABOX cluster", true)
+    if use_iam_role then
+      ciinabox_iam_role_name = get_input('Enter name of iam role to use with CIINABOX cluster [ciinabox]:')
+      ciinabox_iam_role_name = 'ciinabox' if ciinabox_iam_role_name.strip == ''
+    end
 
     ciinabox_docker_repo = get_input('Enter name of private docker repository for images [empty for public images]:')
 

--- a/config/ciinabox_params.yml.erb
+++ b/config/ciinabox_params.yml.erb
@@ -36,7 +36,9 @@ ciinabox_repo: <%= ciinabox_docker_repo %>
 include_diind_slave: <%= include_dind_slave %>
 include_dood_slave: <%= include_dood_slave %>
 
-
+<% if defined? ciinabox_iam_role_name and ciinabox_iam_role_name.strip != '' %>
+ciinabox_iam_role_name: <%= ciinabox_iam_role_name %>
+<% end %>
 #add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)
 #volatile_jenkins_slave: true
 

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -127,6 +127,13 @@ docker_slave_version: 17.03.2-ce
 # If ecr credential helper is configured, it will fail on docker login command
 docker_slave_enable_ecr_credentials_helper: false
 
+# Uncomment line below if you want to use external IAM role for Instance Profile
+# Note that if this options is used, permissions from 'ecs_iam_role_permissions_default'
+# and 'ecs_iam_role_permissions_extras' are disregarded
+
+# ciinabox_iam_role_name: 'ciinabox'
+
+
 ecs_iam_role_permissions_default:
   - name: assume-role
     actions:


### PR DESCRIPTION
Rather than having IAM role created by CloudFormation, allow defining pre-created IAM role through `ciinabox_iam_role_name` configuration key

Rake `:init` task and `:full_install` task will default to having external ciinabox IAM role named 'ciinabox'. 

```
# Uncomment line below if you want to use external IAM role for Instance Profile
# Note that if this options is used, permissions from 'ecs_iam_role_permissions_default'
# and 'ecs_iam_role_permissions_extras' are disregarded

# ciinabox_iam_role_name: 'ciinabox'
```