### PR TITLE
bastion stack, turn on/off task, nat gateway allow incoming connections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'cfndsl','0.15.2'
+gem 'cfn_manage'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ requires ruby 2.1+
 1. git clone https://github.com/base2Services/ciinabox-ecs.git
 2. cd ciinabox-ecs
 3. bundle install
-4. rake -T
+4. bundle exec rake -T
 
 If setting your own parameters and additional services, they should be configured as such:
 
@@ -27,8 +27,8 @@ ciinaboxes/ciinabox_name/config/params.yml
 
 e.g:
 ```ruby
-log_level: :debug
-timezone: Australia/Melbourne
+log_level: ':debug'
+timezone: 'Australia/Melbourne'
 ```
 
 #### User-defined services:
@@ -51,6 +51,18 @@ services:
 Please note that if you wish to do this, that you also need to create a CFNDSL template for the service under templates/services, with the name of the service as the filename (e.g. bitbucket.rb)
 
 ## Getting Started
+
+### Quick setup
+
+You can be guided through full installation of ciinabox by running rake `ciinabox:full_install` task. Interactive 
+command line prompt will offer you defaults for most of required options. 
+
+```bash
+$ bundle exec rake ciinabox:full_install
+
+```
+
+### Step by step setup
 
 1. Initialize/Create a new ciinabox environment. Please note that any user-defined services and parameters will be merged during this task into the default templates
   ```bash
@@ -187,10 +199,10 @@ A common update would be to lock down ip access to your ciinabox environment
 
 2. update your ciinabox
   ```bash
-  $ rake ciinabox:generate
-  $ rake ciinabox:deploy
-  $ rake ciinabox:update
-  $ rake ciinabox:status  
+  $ bundle exec rake ciinabox:generate
+  $ bundle exec rake ciinabox:deploy
+  $ bundle exec rake ciinabox:update
+  $ bundle exec rake ciinabox:status  
   ```
 
 ### ciinabox:tear_down
@@ -203,11 +215,11 @@ Displays the current active ciinabox environment and allows you to change to a d
 
 ### ciinabox:up
 
-Not Yet implemented...pull-request welcome
+Relies on [cfn_manage](https://rubygems.org/gems/cfn_manage) gem to bring stack up. Stack needs to be stopped using `ciinabox:down` task
 
 ### ciinabox:down
 
-Not Yet implemented...pull-request welcome
+Relies on [cfn_manage](https://rubygems.org/gems/cfn_manage) gem to stop the stack. Will set ASG size to 0 (and optionally set bastion ASG size to 0).
 
 ## Adding Custom Templates per ciinabox
 
@@ -269,6 +281,46 @@ internal_elb: false
 
 # Ciinabox configuration
 
+## Bastion (Jumpbox) instance
+
+If you have need to access ECS Cluster instance running Jenkins server via secure shell, you may do so by logging
+into bastion host first. By default, bastion is disabled for ciinabox Cloud Formation stack, however you can enable
+it by using `bastion_stack` configuration key. Bastion will be launched as part of AutoScaling Group of size 1,
+allowing it to self heal in case of system or instance check failure. 
+
+```yaml
+include_bastion_stack: true
+```
+
+It is also possible to override other bastion host parameters, such as Amazon Machine Image and instance type 
+used for Launch Configuration. Defaults are below
+
+```yaml
+bastionInstanceType: t2.micro
+# Amazon Linux 2017.09
+bastionAMI:
+  us-east-1:
+   ami: ami-c5062ba0
+  us-east-2:
+   ami: ami-c5062ba0
+  us-west-2:
+   ami: ami-e689729e
+  us-west-1:
+   ami: ami-02eada62
+  ap-southeast-1:
+   ami: ami-0797ea64
+  ap-southeast-2:
+   ami: ami-8536d6e7
+  eu-west-1:
+   ami: ami-acd005d5
+  eu-west-2:
+   ami: ami-1a7f6d7e
+  eu-central-1:
+   ami: ami-c7ee5ca8
+
+```
+
+
 ## IAM Roles
 
 Default IAM permission for ciinabox stack running Jenkins server are set in `config/default_params.yml`, under
@@ -284,6 +336,17 @@ ecs_iam_role_permissions_extras:
     actions:
       - s3:PutBucketPolicy
 
+```
+
+## Allowing connections from NAT gateway
+
+If ECS Cluster and running Jenkins will try to access itself via public route and url, you will need
+to allow such traffic using Security Group rules. As NAT Gateway is used for sending all requests to internet,
+it is NAT Gateways IP address that should be added to Group rules. Use `allow_nat_connections` configuration 
+key for this.
+
+```yaml
+allow_nat_connections: false
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -310,16 +310,16 @@ namespace :ciinabox do
 
   desc('Turn off your ciinabox environment')
   task :down do
-    check_active_ciinabox(config)
-    puts "Not Yet implemented...pull-request welcome"
-    #find all ASG and set min/max/desired to 0
+    # Use cfn_manage gem for this
+    command = 'stop'
+    start_stop_env(command, config)
   end
 
   desc('Turn on your ciinabox environment')
   task :up do
-    check_active_ciinabox(config)
-    puts "Not Yet implemented...pull-request welcome"
-    #find all ASG and set min/max/desired to 1
+    # Use cfn_manage gem for this
+    command = 'start'
+    start_stop_env(command, config)
   end
 
   desc('Deletes/tears down the ciinabox environment')
@@ -509,5 +509,14 @@ namespace :ciinabox do
     tmp_file << {config: config}.to_yaml
     tmp_file.rewind
     return tmp_file
+  end
+
+  def start_stop_env(command, config)
+    cmd = "cfn_manage #{command}-environment --stack-name #{config['stack_name']} "
+    cmd += " --source-bucket #{config['source_bucket']}"
+    cmd += " --region #{config['source_region']}"
+    cmd += " --profile #{config['aws_profile']}" if not config['aws_profile'].nil?
+    result = system(cmd)
+    exit -1 if not result
   end
 end

--- a/config/ciinabox_params.yml.erb
+++ b/config/ciinabox_params.yml.erb
@@ -35,6 +35,7 @@ ciinabox_repo: <%= ciinabox_docker_repo %>
 
 include_diind_slave: <%= include_dind_slave %>
 include_dood_slave: <%= include_dood_slave %>
+include_bastion_stack: false
 
 <% if defined? ciinabox_iam_role_name and ciinabox_iam_role_name.strip != '' %>
 ciinabox_iam_role_name: <%= ciinabox_iam_role_name %>

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -7,7 +7,7 @@ cluster_name: ciinabox
 stack_name: ciinabox
 
 #log level - change to :debug to see the AWS commands being executed
-log_level: :info
+log_level: ':info'
 
 #change this to your own timezone
 timezone: GMT
@@ -133,6 +133,9 @@ docker_slave_enable_ecr_credentials_helper: false
 
 # ciinabox_iam_role_name: 'ciinabox'
 
+# Indicates whether bastion stack allowing user to access ciinabox host
+# from public network will be created or not
+include_bastion_stack: false
 
 ecs_iam_role_permissions_default:
   - name: assume-role
@@ -249,3 +252,23 @@ ecs_iam_role_permissions_default:
 #      CertName: x
 #      StackOctetA: 11
 #      StackOctetB: 12
+bastionInstanceType: t2.micro
+bastionAMI:
+  us-east-1:
+   ami: ami-c5062ba0
+  us-east-2:
+   ami: ami-c5062ba0
+  us-west-2:
+   ami: ami-e689729e
+  us-west-1:
+   ami: ami-02eada62
+  ap-southeast-1:
+   ami: ami-0797ea64
+  ap-southeast-2:
+   ami: ami-8536d6e7
+  eu-west-1:
+   ami: ami-acd005d5
+  eu-west-2:
+   ami: ami-1a7f6d7e
+  eu-central-1:
+   ami: ami-c7ee5ca8

--- a/templates/bastion.rb
+++ b/templates/bastion.rb
@@ -1,0 +1,109 @@
+CloudFormation do
+
+  # Template metadata
+  AWSTemplateFormatVersion '2010-09-09'
+  Description "ciinabox - Bastion v#{ciinabox_version}"
+
+  # Parameters
+  Parameter('EnvironmentType'){ Type 'String' }
+  Parameter('EnvironmentName'){ Type 'String' }
+  Parameter('VPC'){ Type 'String' }
+  Parameter('RouteTablePrivateA'){ Type 'String' }
+  Parameter('RouteTablePrivateB'){ Type 'String' }
+  Parameter('SubnetPublicA'){ Type 'String' }
+  Parameter('SubnetPublicB'){ Type 'String' }
+  Parameter('SecurityGroupBackplane'){ Type 'String' }
+  Parameter('SecurityGroupOps'){ Type 'String' }
+  Parameter('SecurityGroupDev'){ Type 'String' }
+
+  # Global mappings
+  Mapping('EnvironmentType', Mappings['EnvironmentType'])
+  Mapping('bastionAMI', bastionAMI)
+
+  Resource('Role') {
+    Type 'AWS::IAM::Role'
+    Property('AssumeRolePolicyDocument', {
+        Statement: [
+            Effect: 'Allow',
+            Principal: { Service: [ 'ec2.amazonaws.com' ] },
+            Action: [ 'sts:AssumeRole' ]
+        ]
+    })
+    Property('Path','/')
+    Property('Policies', [
+        {
+            PolicyName: 'associate-address',
+            PolicyDocument: {
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: ['ec2:AssociateAddress'],
+                        Resource: '*'
+                    }
+                ]
+            }
+        }
+    ])
+  }
+
+  InstanceProfile('InstanceProfile') {
+    Path '/'
+    Roles [ Ref('Role') ]
+  }
+
+  Resource('BastionIPAddress') {
+    Type 'AWS::EC2::EIP'
+    Property('Domain', 'vpc')
+  }
+
+  Resource('LaunchConfig') {
+    Type 'AWS::AutoScaling::LaunchConfiguration'
+    DependsOn ['BastionIPAddress']
+    Property('ImageId', FnFindInMap('bastionAMI', Ref('AWS::Region'), 'ami'))
+    Property('KeyName', FnFindInMap('EnvironmentType', 'ciinabox', 'KeyName'))
+    Property('AssociatePublicIpAddress',true)
+    Property('IamInstanceProfile', Ref('InstanceProfile'))
+    FnFindInMap('EnvironmentType', 'ciinabox', 'KeyName')
+    Property('SecurityGroups', [ Ref('SecurityGroupDev'),
+        Ref('SecurityGroupBackplane'),
+        Ref('SecurityGroupOps') ])
+    Property('InstanceType', bastionInstanceType)
+    Property('UserData', FnBase64(FnJoin('',[
+        "#!/bin/bash\n",
+        'export NEW_HOSTNAME=', Ref('EnvironmentName'),"-bastion-xx-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`", "\n",
+        "echo \"NEW_HOSTNAME=$NEW_HOSTNAME\" \n",
+        "hostname $NEW_HOSTNAME\n",
+        "sed -i \"s/^HOSTNAME=.*/HOSTNAME=$NEW_HOSTNAME/\" /etc/sysconfig/network\n",
+        'aws --region ', Ref('AWS::Region'), ' ec2 associate-address --allocation-id ', FnGetAtt('BastionIPAddress','AllocationId') ," --instance-id $(curl http://169.254.169.254/2014-11-05/meta-data/instance-id -s)\n",
+    ])))
+  }
+
+  AutoScalingGroup('AutoScaleGroup') {
+    UpdatePolicy('AutoScalingRollingUpdate', {
+        'MinInstancesInService' => '0',
+        'MaxBatchSize' => '1',
+    })
+    LaunchConfigurationName Ref('LaunchConfig')
+    HealthCheckGracePeriod '500'
+    HealthCheckType 'EC2'
+    MinSize 1
+    MaxSize 1
+    VPCZoneIdentifier [ Ref('SubnetPublicA') ]
+    addTag('Name', FnJoin('-',[Ref('EnvironmentName'), 'bastion' , 'xx']), true)
+    addTag('Environment', Ref('EnvironmentName'), true)
+    addTag('EnvironmentType', Ref('EnvironmentType'), true)
+    addTag('Role', 'bastion', true)
+  }
+
+  Resource('BastionRecordSet') {
+    Type 'AWS::Route53::RecordSet'
+    DependsOn ['BastionIPAddress']
+    Property('HostedZoneName', FnJoin('', [ dns_domain, '.' ]))
+    Property('Comment', 'Bastion record set')
+    Property('Name', FnJoin('', [ 'bastion.',  Ref('EnvironmentName') , '.', dns_domain, '.' ]))
+    Property('Type', 'A')
+    Property('TTL', '60')
+    Property('ResourceRecords', [  Ref('BastionIPAddress') ] )
+  }
+
+end

--- a/templates/ciinabox.rb
+++ b/templates/ciinabox.rb
@@ -29,8 +29,7 @@ CloudFormation do
       RouteTablePrivateB: FnGetAtt('VPCStack', 'Outputs.RouteTablePrivateB'),
       SubnetPublicA: FnGetAtt('VPCStack', 'Outputs.SubnetPublicA'),
       SubnetPublicB: FnGetAtt('VPCStack', 'Outputs.SubnetPublicB'),
-      SecurityGroupBackplane: FnGetAtt('VPCStack', 'Outputs.SecurityGroupBackplane'),
-      SecurityGroupNatGateway: FnGetAtt('VPCStack', 'Outputs.SecurityGroupNatGateway')
+      SecurityGroupBackplane: FnGetAtt('VPCStack', 'Outputs.SecurityGroupBackplane')
     })
   }
 
@@ -48,7 +47,8 @@ CloudFormation do
       ECSSubnetPrivateB: FnGetAtt('ECSStack', 'Outputs.ECSSubnetPrivateB'),
       SecurityGroupBackplane: FnGetAtt('VPCStack', 'Outputs.SecurityGroupBackplane'),
       SecurityGroupOps: FnGetAtt('VPCStack', 'Outputs.SecurityGroupOps'),
-      SecurityGroupDev: FnGetAtt('VPCStack', 'Outputs.SecurityGroupDev')
+      SecurityGroupDev: FnGetAtt('VPCStack', 'Outputs.SecurityGroupDev'),
+      SecurityGroupNatGateway: FnGetAtt('VPCStack', 'Outputs.SecurityGroupNatGateway')
     })
   }
 
@@ -66,6 +66,13 @@ CloudFormation do
     base_params.merge!("SubnetPublic#{az}" => FnGetAtt('VPCStack', "Outputs.SubnetPublic#{az}"))
     base_params.merge!("RouteTablePrivate#{az}" => FnGetAtt('VPCStack', "Outputs.RouteTablePrivate#{az}"))
   end
+
+  # Bastion if required
+  Resource('BastionStack') do
+    Type 'AWS::CloudFormation::Stack'
+    Property('TemplateURL', "https://#{source_bucket}.s3.amazonaws.com/ciinabox/#{ciinabox_version}/bastion.json")
+    Property('Parameters', base_params)
+  end if include_bastion_stack
 
   #Foreign templates
   #e.g CIINABOXES_DIR/CIINABOX/templates/x.rb

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -24,7 +24,6 @@ CloudFormation {
   Parameter("SubnetPublicA") {Type 'String'}
   Parameter("SubnetPublicB") {Type 'String'}
   Parameter("SecurityGroupBackplane") {Type 'String'}
-  Parameter('SecurityGroupNatGateway') {Type 'String'}
 
 
   # Global mappings
@@ -125,7 +124,7 @@ CloudFormation {
     }
   end
 
-  ecs_sgs = (defined? allow_nat_connections and allow_nat_connections) ? [Ref('SecurityGroupBackplane'), Ref('SecurityGroupNatGateway')] : [Ref('SecurityGroupBackplane')]
+  ecs_sgs = [Ref('SecurityGroupBackplane')]
 
   LaunchConfiguration(:LaunchConfig) {
     ImageId FnFindInMap('ecsAMI', Ref('AWS::Region'), 'ami')


### PR DESCRIPTION
1.  Implemented `ciinabox:down` and `ciinabox:up` tasks
2. Optional bastion stack added
3. Allowing NAT gateway connections has been fixed to allow connections on ELB rather than on instance itself
4. README has been improved to include `bundle exec` rather than just running rake directly, avoiding possible dependency problems

### ciinabox:up

Relies on [cfn_manage](https://rubygems.org/gems/cfn_manage) gem to bring stack up. Stack needs to be stopped using `ciinabox:down` task

### ciinabox:down

Relies on [cfn_manage](https://rubygems.org/gems/cfn_manage) gem to stop the stack. Will set ASG size to 0 (and optionally set bastion ASG size to 0).


## Bastion (Jumpbox) instance

If you have need to access ECS Cluster instance running Jenkins server via secure shell, you may do so by logging
into bastion host first. By default, bastion is disabled for ciinabox Cloud Formation stack, however you can enable
it by using `bastion_stack` configuration key. Bastion will be launched as part of AutoScaling Group of size 1,
allowing it to self heal in case of system or instance check failure. 

```yaml
include_bastion_stack: true
```

It is also possible to override other bastion host parameters, such as Amazon Machine Image and instance type 
used for Launch Configuration. Defaults are below

```yaml
bastionInstanceType: t2.micro
# Amazon Linux 2017.09
bastionAMI:
  us-east-1:
   ami: ami-c5062ba0
  us-east-2:
   ami: ami-c5062ba0
  us-west-2:
   ami: ami-e689729e
  us-west-1:
   ami: ami-02eada62
  ap-southeast-1:
   ami: ami-0797ea64
  ap-southeast-2:
   ami: ami-8536d6e7
  eu-west-1:
   ami: ami-acd005d5
  eu-west-2:
   ami: ami-1a7f6d7e
  eu-central-1:
   ami: ami-c7ee5ca8

``` 

## Allowing connections from NAT gateway

If ECS Cluster and running Jenkins will try to access itself via public route and url, you will need
to allow such traffic using Security Group rules. As NAT Gateway is used for sending all requests to internet,
it is NAT Gateways IP address that should be added to Group rules. Use `allow_nat_connections` configuration 
key for this.

```yaml
allow_nat_connections: false
```
