### PR TITLE
Overrides in ciinabox dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,6 +67,9 @@ namespace :ciinabox do
 
     CfnDsl::RakeTask.new do |t|
       extras = [[:yaml,'config/default_params.yml']]
+      if File.exist? "#{ciinaboxes_dir}/ciinabox_config.yml"
+        extras << [:yaml, "#{ciinaboxes_dir}/ciinabox_config.yml"]
+      end
       (Dir["#{ciinaboxes_dir}/#{ciinabox_name}/config/*.yml"].map { |f| [:yaml,f]}).each {|c| extras<<c}
       extras << [:ruby,'ext/helper.rb']
       extras << [:yaml, tmp_file.path]

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -132,10 +132,16 @@ docker_slave_enable_ecr_credentials_helper: false
 # and 'ecs_iam_role_permissions_extras' are disregarded
 
 # ciinabox_iam_role_name: 'ciinabox'
-
 # Indicates whether bastion stack allowing user to access ciinabox host
 # from public network will be created or not
 include_bastion_stack: false
+
+# if set to true, docker volume will be formatted as ext4 and volume-mounted under /var/lib/docker.
+# Used if ECS AMI is configured with overlay2 driver. Defaults to false, as Amazon ECS AMIs (default)
+# are using devicemapper, which gets configured automatically. Main advantage of using overlay2 over devicemapper is
+# device size limitation
+ecs_docker_volume_volumemount: false
+
 
 ecs_iam_role_permissions_default:
   - name: assume-role


### PR DESCRIPTION
Allow `ciinabox_config.yml` configuration override in `ciinaboxes_dir` (defaults to `ciinaboxes`). Any configuration from `default_params.yml` that needs to be overwriten and shared  amongst all cinnaboxes can be places in this file. 