### PR TITLE
Ciinabox ecs updates

### DIFF
--- a/config/ciinabox_params.yml.erb
+++ b/config/ciinabox_params.yml.erb
@@ -37,7 +37,7 @@ include_diind_slave: <%= include_dind_slave %>
 include_dood_slave: <%= include_dood_slave %>
 include_bastion_stack: false
 
-<% if defined? ciinabox_iam_role_name and ciinabox_iam_role_name.strip != '' %>
+<% if (defined? ciinabox_iam_role_name) and (not ciinabox_iam_role_name.nil?) and (ciinabox_iam_role_name.strip != '') %>
 ciinabox_iam_role_name: <%= ciinabox_iam_role_name %>
 <% end %>
 #add if you want volatile jenkins docker slave -- Note: by default jenkins docker slave mounts /data/jenkins-dind (on host) to /var/lib/docker (on container)

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -143,6 +143,14 @@ include_bastion_stack: false
 ecs_docker_volume_volumemount: false
 
 
+# if set to true, EBS data volumes will be tagged to be backed up with shelvery aws backup manager
+# also, retention periods can be controlled from here
+data_volume_shelvery_backups: true
+data_volume_retain_daily_backups: 7
+data_volume_retain_weekly_backups: 4
+data_volume_reatin_monthly_backups: 12
+
+
 ecs_iam_role_permissions_default:
   - name: assume-role
     actions:
@@ -261,7 +269,7 @@ ecs_iam_role_permissions_default:
 bastionInstanceType: t2.micro
 bastionAMI:
   us-east-1:
-   ami: ami-c5062ba0
+   ami: ami-55ef662f
   us-east-2:
    ami: ami-c5062ba0
   us-west-2:

--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -96,11 +96,17 @@ CloudFormation {
       SnapshotId ecs_data_volume_snapshot
     end
     AvailabilityZone FnSelect(0, FnGetAZs(""))
-    addTag("Name", "ciinabox-ecs-data-xx")
-    addTag("Environment", 'ciinabox')
-    addTag("EnvironmentType", 'ciinabox')
-    addTag("Role", "ciinabox-data")
-    addTag("MakeSnapshot", "true")
+    addTag('Name', 'ciinabox-ecs-data-xx')
+    addTag('Environment', 'ciinabox')
+    addTag('EnvironmentType', 'ciinabox')
+    addTag('Role', 'ciinabox-data')
+    if data_volume_shelvery_backups
+      addTag('shelvery:create_backup','true')
+      addTag('shelvery:config:shelvery_keep_daily_backups', data_volume_retain_daily_backups)
+      addTag('shelvery:config:shelvery_keep_weekly_backups', data_volume_retain_weekly_backups)
+      addTag('shelvery:config:shelvery_keep_monthly_backups', data_volume_reatin_monthly_backups)
+    end
+
   }
 
   ecs_block_device_mapping = []

--- a/templates/services/jenkins.rb
+++ b/templates/services/jenkins.rb
@@ -18,7 +18,7 @@ if not defined? ciinabox_repo
   ciinabox_repo=''
 end
 
-image = "#{ciinabox_repo}base2/ciinabox-jenkins:2"
+image = "#{ciinabox_repo}base2/ciinabox-jenkins:lts"
 
 jenkins_java_opts = ''
 memory = 2048


### PR DESCRIPTION
# Updates

- Jenkins will be ran as `lts` image by default
- Including tags for EBS Data volume backups via [shelvery](https://github.com/base2Services/shelvery) 

# Bug fixes

- Bastion AMI for `us-east-1` region was invalid. Replacing with Amazon Linux 2017.09 AMI