### PR TITLE
include Policies for Lambdas

### DIFF
--- a/templates/lambdas.rb
+++ b/templates/lambdas.rb
@@ -1,7 +1,7 @@
 require 'cfndsl'
 require 'digest'
 require 'base64'
-
+require_relative '../ext/policies'
 class Lambdas
 
 


### PR DESCRIPTION
## Problem

When using feature of deploying AWS Lambda Functions within ciinabox, `cfndsl` compilation fails due missing reference to Policies helper. 

## Solution

Policies helper referenced in lambda templates

## Testing

Deploying ciinabox with lambda functions

