### PR TITLE
Convert from running ciinabox-ecs as rake tasks to gem

### DIFF
--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -1,0 +1,14 @@
+## Contributing guidelines
+
+
+### Adding new actions
+
+Currently all actions are implemented as Rake tasks, and wrapped using `bin/ciinabox-ecs.rb` cli handler.
+Ciinabox name is set as last name of the action. If you are adding action that does not take ciinabox
+as argument - such as initialisation tasks, you'll need to add exception for not requiring ciinabox name
+for that task within CLI wrapper.
+
+
+### Adding new services
+
+- Add template in `templates/services/service_name.rb`

--- a/Rakefile
+++ b/Rakefile
@@ -198,7 +198,7 @@ namespace :ciinabox do
   task :status do
     check_active_ciinabox(config)
     status, result = aws_execute(config, ['cloudformation', 'describe-stacks', "--stack-name #{stack_name}", '--query "Stacks[0].StackStatus"', '--out text'])
-    if status > 0
+    if status != 0
       puts "fail to get status for #{config['ciinabox_name']}...has it been created?"
       exit 1
     end
@@ -215,10 +215,10 @@ namespace :ciinabox do
   task :create_source_bucket do
     check_active_ciinabox(config)
     status, result = aws_execute(config, ['s3', 'ls', "s3://#{config['source_bucket']}/ciinabox/#{config['ciinabox_version']}/"])
-    if status > 0
+    if status != 0
       status, result = aws_execute(config, ['s3', 'mb', "s3://#{config['source_bucket']}"])
       puts result
-      if status > 0
+      if status != 0
         puts "fail to create source bucket see error logs for details"
         exit status
       else
@@ -258,7 +258,7 @@ namespace :ciinabox do
         "--private-key file://#{cert_dir}/ssl/ciinabox.key",
         "--certificate-chain file://#{cert_dir}/ssl/ciinabox.crt"
     ])
-    if status > 0
+    if status != 0
       puts "fail to create or update IAM server-certificates. See error logs for details"
       puts result
       exit status
@@ -285,7 +285,7 @@ namespace :ciinabox do
         "--out text"
     ], "#{keypair_dir}/ciinabox.pem")
     puts result
-    if status > 0
+    if status != 0
       puts "fail to create keypair see error logs for details"
       exit status
     else
@@ -299,7 +299,7 @@ namespace :ciinabox do
     check_active_ciinabox(config)
     status, result = aws_execute(config, ['s3', 'sync', 'output/', "s3://#{config['source_bucket']}/ciinabox/#{config['ciinabox_version']}/"])
     puts result
-    if status > 0
+    if status != 0
       puts "fail to upload rendered templates to S3 bucket #{config['source_bucket']}"
       exit status
     else
@@ -316,7 +316,7 @@ namespace :ciinabox do
         '--capabilities CAPABILITY_IAM'
     ])
     puts result
-    if status > 0
+    if status != 0
       puts "Failed to create ciinabox environment"
       exit status
     else
@@ -333,7 +333,7 @@ namespace :ciinabox do
         '--capabilities CAPABILITY_IAM'
     ])
     puts result
-    if status > 0
+    if status != 0
       puts "Failed to update ciinabox environment"
       exit status
     else
@@ -363,7 +363,7 @@ namespace :ciinabox do
     if input == 'y'
       status, result = aws_execute(config, ['cloudformation', 'delete-stack', "--stack-name #{stack_name}"])
       puts result
-      if status > 0
+      if status != 0
         puts "fail to tear down ciinabox environment"
         exit status
       else
@@ -597,7 +597,7 @@ namespace :ciinabox do
         '--query Reservations[*].Instances[?Tags[?Value==\`ciinabox-ecs\`]].PrivateIpAddress',
         '--out text'
     ])
-    if status > 0
+    if status != 0
       return nil
     else
       return result

--- a/Rakefile
+++ b/Rakefile
@@ -9,12 +9,16 @@ require 'securerandom'
 require 'base64'
 require 'tempfile'
 require 'json'
-require_relative 'ext/common_helper'
-require_relative 'ext/zip_helper'
+require_relative './ext/common_helper'
+require_relative './ext/zip_helper'
+require 'ciinabox-ecs' if Gem::Specification::find_all_by_name('ciinabox-ecs').any?
+
 namespace :ciinabox do
 
   #load config
-  templates = Dir["templates/**/*.rb"]
+  current_dir = File.expand_path File.dirname(__FILE__)
+
+  templates = Dir["#{current_dir}/templates/**/*.rb"]
   ciinaboxes_dir = ENV['CIINABOXES_DIR'] || 'ciinaboxes'
   ciinabox_name = ENV['CIINABOX'] || ''
 
@@ -22,8 +26,8 @@ namespace :ciinabox do
   @ciinabox_name = ciinabox_name
 
   #Load and merge standard ciinabox-provided parameters
-  default_params = YAML.load(File.read("config/default_params.yml")) if File.exist?("config/default_params.yml")
-  lambda_params = YAML.load(File.read('config/default_lambdas.yml'))
+  default_params = YAML.load(File.read("#{current_dir}/config/default_params.yml")) if File.exist?("#{current_dir}/config/default_params.yml")
+  lambda_params = YAML.load(File.read("#{current_dir}/config/default_lambdas.yml"))
   default_params.merge!(lambda_params)
 
   if File.exist?("#{ciinaboxes_dir}/#{ciinabox_name}/config/params.yml")
@@ -42,7 +46,14 @@ namespace :ciinabox do
   config['lambdas'] = {} unless config.key? 'lambdas'
   config['lambdas'].extend(config['default_lambdas'])
 
-  File.write('debug.config.yaml',config.to_yaml) if ENV['DEBUG']
+  # ciinabox binary version
+  if Gem.loaded_specs['ciinabox-ecs'].nil?
+    config['ciinabox_binary_version'] = `git rev-parse --short HEAD`.gsub("\n",'')
+  else
+    config['ciinabox_binary_version'] = Gem.loaded_specs['ciinabox-ecs'].version.to_s
+  end
+
+  File.write('debug-ciinabox.config.yaml',config.to_yaml) if ENV['DEBUG']
 
   stack_name = config["stack_name"] || "ciinabox"
 
@@ -76,13 +87,13 @@ namespace :ciinabox do
     tmp_file = write_config_tmp_file(config)
 
     CfnDsl::RakeTask.new do |t|
-      extras = [[:yaml, 'config/default_params.yml']]
-      extras << [:yaml, 'config/default_lambdas.yml']
+      extras = [[:yaml,"#{current_dir}/config/default_params.yml"]]
+      extras << [:yaml, "#{current_dir}/config/default_lambdas.yml"]
       if File.exist? "#{ciinaboxes_dir}/ciinabox_config.yml"
         extras << [:yaml, "#{ciinaboxes_dir}/ciinabox_config.yml"]
       end
-      (Dir["#{ciinaboxes_dir}/#{ciinabox_name}/config/*.yml"].map { |f| [:yaml, f] }).each { |c| extras<<c }
-      extras << [:ruby, 'ext/helper.rb']
+      (Dir["#{ciinaboxes_dir}/#{ciinabox_name}/config/*.yml"].map { |f| [:yaml,f]}).each {|c| extras<<c}
+      extras << [:ruby,"#{current_dir}/ext/helper.rb"]
       extras << [:yaml, tmp_file.path]
       t.cfndsl_opts = {
           verbose: true,
@@ -148,7 +159,7 @@ namespace :ciinabox do
 
     #Settings preference - 1) User-input 2) User-provided params.yml 3) Default template
 
-    ciinabox_params = File.read('config/ciinabox_params.yml.erb')
+    ciinabox_params = File.read("#{current_dir}/config/ciinabox_params.yml.erb")
     input_result = ERB.new(ciinabox_params).result(binding)
     input_hash = YAML.load(input_result) #Converts user input to hash
     if File.exist?("#{ciinaboxes_dir}/#{ciinabox_name}/config/params.yml")
@@ -159,7 +170,7 @@ namespace :ciinabox do
       File.open("#{ciinaboxes_dir}/#{ciinabox_name}/config/params.yml", 'w') { |f| f.write(input_result) }
     end
 
-    default_services = YAML.load(File.read("config/default_services.yml"))
+    default_services = YAML.load(File.read("#{current_dir}/config/default_services.yml"))
 
     class ::Hash
       def deep_merge(second)
@@ -182,11 +193,6 @@ namespace :ciinabox do
     display_active_ciinabox ciinaboxes_dir, ciinabox_name
   end
 
-  desc('Switch active ciinabox')
-  task :active, :ciinabox do |t, args|
-    ciinabox = args[:ciinabox] || ciinabox_name
-    display_active_ciinabox ciinaboxes_dir, ciinabox
-  end
 
   desc('Current status of the active ciinabox')
   task :status do
@@ -291,7 +297,7 @@ namespace :ciinabox do
   desc('Deploy Cloudformation templates to S3')
   task :deploy do
     check_active_ciinabox(config)
-    status, result = aws_execute(config, ['s3', 'sync', '--delete', 'output/', "s3://#{config['source_bucket']}/ciinabox/#{config['ciinabox_version']}/"])
+    status, result = aws_execute(config, ['s3', 'sync', 'output/', "s3://#{config['source_bucket']}/ciinabox/#{config['ciinabox_version']}/"])
     puts result
     if status > 0
       puts "fail to upload rendered templates to S3 bucket #{config['source_bucket']}"
@@ -393,17 +399,32 @@ namespace :ciinabox do
       config['lambdas']['functions'].each do |name, lambda_config|
         timestamp = Time.now.getutc.to_i
         # create folder
+
         config_file_folder = "output/lambdas/#{name}/#{timestamp}"
         FileUtils.mkdir_p config_file_folder
 
         # download file if code remote archive
         puts "Processing function #{name}...\n"
 
-        lambda_source_dir = File.dirname(lambda_config['code'])
-        lambda_source_dir = "#{ciinaboxes_dir}/#{ciinabox_name}/#{lambda_source_dir}" unless (lambda_config.key? 'local' and lambda_config['local'])
-        lambda_source_file = File.basename(lambda_config['code'])
-        lambda_source_file = '.' if Pathname.new(lambda_config['code']).directory?
-        lambda_source_dir = lambda_config['code'] if Pathname.new(lambda_config['code']).directory?
+        if lambda_config['local']
+          lambda_source_path = "#{current_dir}/#{lambda_config['code']}" if lambda_config['local']
+          lambda_source_file = File.basename(lambda_source_path)
+          tmpdir = "output/package_lambdas/#{name}"
+          FileUtils.mkdir_p tmpdir
+          FileUtils.cp_r(lambda_source_path, tmpdir)
+          lambda_source_path = "#{tmpdir}/#{lambda_source_file}"
+        else
+          lambda_source_path = "#{ciinaboxes_dir}/#{ciinabox_name}/#{lambda_config['code']}"
+        end
+
+        lambda_source_dir = File.dirname(lambda_source_path)
+
+        lambda_source_file = File.basename(lambda_source_path)
+        lambda_source_file = '.' if Pathname.new(lambda_source_path).directory?
+
+        lambda_source_dir = lambda_source_path if Pathname.new(lambda_source_path).directory?
+        puts "Lambda source path: #{lambda_source_path}"
+        puts "Lambda source dir: #{lambda_source_dir}"
 
         unless lambda_config['package_cmd'].nil?
           package_cmd = "cd #{lambda_source_dir} && #{lambda_config['package_cmd']}"
@@ -440,6 +461,8 @@ namespace :ciinabox do
         lambda_config['code_sha256'] = sha256
         lambda_config['timestamp'] = timestamp
       end
+
+      FileUtils.rmtree 'output/package_lambdas'
     end
   end
 
@@ -532,7 +555,7 @@ namespace :ciinabox do
 
   def check_active_ciinabox(config)
     if (config.nil? || config['ciinabox_name'].nil?)
-      puts "no active ciinabox please...run rake ciinabox:active or ciinabox:init"
+      puts "no active ciinabox - either export CIINABOX variable or set ciinabox name as last command line argument"
       exit 1
     end
   end
@@ -556,8 +579,6 @@ namespace :ciinabox do
     puts "# Enable active ciinabox by executing or override ciinaboxes base directory:"
     puts "export CIINABOXES_DIR=\"#{ciinaboxes_dir}\""
     puts "export CIINABOX=\"#{ciinabox}\""
-    puts "# or run"
-    puts "# eval \"$(rake ciinabox:active[#{ciinabox}])\""
   end
 
   def display_ecs_ip_address(config)

--- a/bin/Rakefile
+++ b/bin/Rakefile
@@ -1,0 +1,1 @@
+import './../Rakefile'

--- a/bin/ciinabox-ecs
+++ b/bin/ciinabox-ecs
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+require_relative('./ciinabox-ecs')

--- a/bin/ciinabox-ecs.rb
+++ b/bin/ciinabox-ecs.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+require 'rake'
+require 'optparse'
+
+class CiinaboxEcsCli
+
+  def main(args)
+    script_dir = File.expand_path File.dirname(__FILE__)
+    old_pwd = Dir.pwd
+
+    Rake::TaskManager.record_task_metadata = true
+
+    Dir.chdir script_dir
+    app = Rake.application
+    app.init
+    app.load_rakefile
+
+    actions = app.tasks.map { |t| t.name.gsub('ciinabox:', '') }
+
+    required_args_size = ENV.key?('CIINABOX') ? 1 : 2
+
+    if (args.size() ==0) or
+        (args.size() < required_args_size and (not %w(init full_install).include? args[0])) or
+        (args[0] == 'help') or
+        (not actions.include? args[0])
+      STDERR.puts("Usage: ciinabox-ecs action1 action2 action3 ciinabox_name")
+      STDERR.puts("Valid actions:")
+      STDERR.printf("%-20s |%-20s\n\n", 'name', 'description')
+      app.tasks.each do |action|
+        STDERR.printf("%-20s |%-20s\n", action.name.gsub('ciinabox:', ''), action.comment)
+      end
+      exit 0 if args[0] == 'help'
+      exit -1
+    end
+
+    methods = args[0..args.size()-2]
+
+    unless ENV.key? 'CIINABOX'
+      ciinabox_name = args[args.size()-1]
+      ENV['CIINABOX'] = ciinabox_name
+    end
+
+    if ENV.key? 'CIINABOXES_DIR'
+      ENV['CIINABOXES_DIR'] = File.expand_path(ENV['CIINABOXES_DIR'])
+    else
+      ENV['CIINABOXES_DIR'] = old_pwd
+    end
+
+    methods.each do |method_name|
+      Dir.chdir(script_dir)
+      Rake.application = nil
+      app = Rake.application
+      app.init
+      app.load_rakefile
+      Dir.chdir(old_pwd)
+      app["ciinabox:#{method_name}"].invoke()
+    end
+
+  end
+
+end
+
+CiinaboxEcsCli.new.main(ARGV)

--- a/ciinabox_ecs.gemspec
+++ b/ciinabox_ecs.gemspec
@@ -2,7 +2,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'ciinabox-ecs'
-  s.version = '0.2.7'
+  s.version = '0.2.8'
   s.date = '2018-05-07'
   s.summary = 'Manage ciinabox on Aws Ecs'
   s.description = ''
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.add_runtime_dependency 'rake', '~>12'
   s.add_runtime_dependency 'cfndsl', '~>0.15.2'
-  s.add_runtime_dependency 'cfn_manage', '~>0.2.7'
+  s.add_runtime_dependency 'cfn_manage', '~>0.3.0'
   s.add_runtime_dependency 'deep_merge', '~>1.2'
   s.add_runtime_dependency 'rubyzip', '~> 1.2'
 end

--- a/ciinabox_ecs.gemspec
+++ b/ciinabox_ecs.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'ciinabox-ecs'
-  s.version = '0.2.6'
-  s.date = '2018-03-23'
+  s.version = '0.2.7'
+  s.date = '2018-05-07'
   s.summary = 'Manage ciinabox on Aws Ecs'
   s.description = ''
   s.authors = ['Base2Services']

--- a/ciinabox_ecs.gemspec
+++ b/ciinabox_ecs.gemspec
@@ -1,0 +1,21 @@
+require 'rake'
+
+Gem::Specification.new do |s|
+  s.name = 'ciinabox-ecs'
+  s.version = '0.2.6'
+  s.date = '2018-03-23'
+  s.summary = 'Manage ciinabox on Aws Ecs'
+  s.description = ''
+  s.authors = ['Base2Services']
+  s.email = 'itsupport@base2services.com'
+  s.files = FileList['lib/**/*.rb','ext/**/*', 'config/**/*', 'bin/**/*', 'lambdas/**/*', 'templates/**/*', 'Gemfile', 'Rakefile', 'README.md', 'LICENSE.txt']
+  s.homepage = 'https://github.com/base2Services/ciinabox-ecs'
+  s.license = 'MIT'
+  s.executables << 'ciinabox-ecs'
+  s.require_paths = ['lib']
+  s.add_runtime_dependency 'rake', '~>12'
+  s.add_runtime_dependency 'cfndsl', '~>0.15.2'
+  s.add_runtime_dependency 'cfn_manage', '~>0.2.7'
+  s.add_runtime_dependency 'deep_merge', '~>1.2'
+  s.add_runtime_dependency 'rubyzip', '~> 1.2'
+end

--- a/config/default_lambdas.yml
+++ b/config/default_lambdas.yml
@@ -13,7 +13,7 @@ default_lambdas:
     CRIssueACMCertificate:
       local: true
       role: acmissuevalidate
-      package_cmd: ../install.sh
+      package_cmd: ./install.sh
       runtime: python3.6
       code: lambdas/acm_issuer_validator/lib
       vpc: false

--- a/config/default_params.yml
+++ b/config/default_params.yml
@@ -73,30 +73,38 @@ Mappings:
       NatInstanceType: t2.micro
       ECSInstanceType: t2.large
 
-#Amazon Linux AMI 2015.03.1 (HVM), SSD Volume Type
-natAMI:
-  us-east-1:
-    ami: ami-60b6c60a
-  us-west-2:
-    ami: ami-f0091d91
-  ap-southeast-2:
-    ami: ami-48d38c2b
-  eu-west-1:
-    ami: ami-bff32ccc
-  ap-southeast-1:
-    ami: ami-c9b572aa
 
 ecs_ami:
   us-east-1:
     ami: ami-04351e12
-  us-west-2:
-    ami: ami-57d9cd2e
-  ap-southeast-2:
-    ami: ami-42e9f921
+  us-east-2:
+    ami: ami-1b90a67e
+  us-west-1:
+    ami: ami-9cbbaffc
+  eu-west-3:
+    ami: ami-914afcec
+  eu-west-2:
+    ami: ami-a48d6bc3
   eu-west-1:
-    ami: ami-809f84e6
+    ami: ami-bfb5fec6
+  eu-central-1:
+    ami: ami-ac055447
+  us-west-2:
+    ami: ami-05b5277d
+  ap-southeast-2:
+    ami: ami-4cc5072e
   ap-southeast-1:
-    ami: ami-19f7787a
+    ami: ami-acbcefd0
+  ap-northeast-2:
+    ami: ami-ba74d8d4
+  ap-northeast-1:
+    ami: ami-5add893c
+  ca-central-1:
+    ami: ami-a535b2c1
+  ap-south-1:
+    ami: ami-2149114e
+  sa-east-1:
+    ami: ami-d3bce9bf
 
 #Webhook access only via https
 webHooks:

--- a/ext/policies.rb
+++ b/ext/policies.rb
@@ -2,7 +2,8 @@ require 'yaml'
 
 module Configs
   class << self; attr_accessor :managed_policies, :all end
-  @managed_policies = YAML.load(File.read('ext/config/managed_policies.yml'))
+  script_dir  = File.expand_path File.dirname(__FILE__)
+  @managed_policies = YAML.load(File.read("#{script_dir}/config/managed_policies.yml"))
   @all = Hash.new.tap { |h| Dir['config/*.yml'].each { |yml| h.merge!(YAML.load(File.open(yml))) }}
   # Override with ciinabox configs
   ciinaboxes_dir = ENV['CIINABOXES_DIR'] || 'ciinaboxes'

--- a/lib/ciinabox-ecs.rb
+++ b/lib/ciinabox-ecs.rb
@@ -1,0 +1,5 @@
+module CiinaboxEcs
+
+
+
+end

--- a/templates/ciinabox.rb
+++ b/templates/ciinabox.rb
@@ -1,10 +1,11 @@
 require_relative '../ext/policies'
-
 CloudFormation do
+
+  ciinabox_binary_version = config['ciinabox_binary_version']
 
   # Template metadata
   AWSTemplateFormatVersion '2010-09-09'
-  Description "ciinabox ECS - Master v#{ciinabox_version}"
+  Description "ciinabox ECS #{ciinabox_binary_version} - v#{ciinabox_version}"
 
   Resource(cluster_name) {
     Type 'AWS::ECS::Cluster'
@@ -154,6 +155,14 @@ CloudFormation do
 
   Output('DefaultSSLCertificate'){
     Value(FnGetAtt('ECSServicesStack','Outputs.DefaultSSLCertificate'))
+  }
+
+  Output('CiinaboxBinaryVersion'){
+    Value(ciinabox_binary_version)
+  }
+
+  Output('CiinaboxName'){
+    Value(ciinabox_name)
   }
 
 end

--- a/templates/services/artifactory.rb
+++ b/templates/services/artifactory.rb
@@ -1,0 +1,119 @@
+require 'cfndsl'
+require_relative '../../ext/helper'
+
+if !defined? timezone
+  timezone = 'GMT'
+end
+
+image = 'base2/ciinabox-artifactory:5.9.3'
+java_opts = ''
+memory = 1024
+cpu = 0
+container_port = 0
+service = lookup_service('artifactory', services)
+if service
+  service = {} if service.nil?
+  java_opts = service['JAVA_OPTS'] || ''
+  image = service['ContainerImage'] || image
+  memory = service['ContainerMemory'] || memory
+  cpu = service['ContainerCPU'] || cpu
+  container_port = service['InstancePort'] || 0
+end
+
+CloudFormation {
+
+  AWSTemplateFormatVersion "2010-09-09"
+  Description "ciinabox - ECS Service Artifactory v#{ciinabox_version}"
+
+  Parameter("ECSCluster"){ Type 'String' }
+  Parameter("ECSRole"){ Type 'String' }
+  Parameter("ServiceELB"){ Type 'String' }
+
+  Resource('ArtifactoryTask') {
+    Type "AWS::ECS::TaskDefinition"
+    Property('ContainerDefinitions', [
+      {
+        Name: 'artifactory',
+        Memory: memory,
+        Cpu: cpu,
+        Image: image,
+        Environment: [
+          {
+            Name: 'JAVA_OPTS',
+            Value: "#{java_opts} -Duser.timezone=#{timezone} -server -Djava.net.preferIPv4Stack=true"
+          },
+          {
+            Name: 'VIRTUAL_HOST',
+            Value: "artifactory.#{dns_domain}"
+          },
+          {
+            Name: 'VIRTUAL_PORT',
+            Value: '8081'
+          }
+        ],
+        Essential: true,
+        MountPoints: [
+          {
+            ContainerPath: '/etc/localtime',
+            SourceVolume: 'timezone',
+            ReadOnly: true
+          },
+          {
+            ContainerPath: '/var/opt/jfrog/artifactory/data',
+            SourceVolume: 'artifactory_data',
+            ReadOnly: false
+          },
+            {
+                ContainerPath: '/var/opt/jfrog/artifactory/etc',
+                SourceVolume: 'artifactory_etc',
+                ReadOnly: false
+            },
+            {
+                ContainerPath: '/var/opt/jfrog/artifactory/logs',
+                SourceVolume: 'artifactory_logs',
+                ReadOnly: false
+            }
+        ]
+      }
+    ])
+    Property('Volumes', [
+      {
+        Name: 'timezone',
+        Host: {
+          SourcePath: '/etc/localtime'
+        }
+      },
+      {
+        Name: 'artifactory_data',
+        Host: {
+          SourcePath: '/data/artifactory/data'
+        }
+      },
+      {
+          Name: 'artifactory_etc',
+          Host: {
+              SourcePath: '/data/artifactory/etc'
+          }
+      },
+      {
+          Name: 'artifactory_logs',
+          Host: {
+              SourcePath: '/data/artifactory/logs'
+          }
+      }
+    ])
+  }
+
+  Resource('ArtifactoryService') {
+    Type 'AWS::ECS::Service'
+    Property('Cluster', Ref('ECSCluster'))
+    Property('DesiredCount', 1)
+    Property('TaskDefinition', Ref('ArtifactoryTask'))
+    Property('Role', Ref('ECSRole')) unless container_port == 0
+    Property('LoadBalancers', [
+      { ContainerName: 'artifactory', ContainerPort: container_port, LoadBalancerName: Ref('ServiceELB') }
+    ]) unless container_port == 0
+
+  }
+
+}

--- a/templates/services/jenkins.rb
+++ b/templates/services/jenkins.rb
@@ -33,6 +33,7 @@ end
 port_mappings = []
 
 if defined? service
+  service = {} if service.nil?
   jenkins_java_opts = service['JAVA_OPTS'] || ''
   image = service['ContainerImage'] || image
   memory = service['ContainerMemory'] || 2048

--- a/templates/vpc.rb
+++ b/templates/vpc.rb
@@ -9,7 +9,6 @@ CloudFormation {
 
   # Global mappings
   Mapping('EnvironmentType', Mappings['EnvironmentType'])
-  Mapping('NatAMI', natAMI)
 
   # Resources
   Resource("VPC") {


### PR DESCRIPTION
## Allow running ciinabox-ecs as a gem

By embedding gem version if root stack template, and outputting as stack parameter, mass management of ciinabox-ecs installations becomes easier (versions are tracked). If Rakefile method is used rather than gem, short git sha1 will be embedded and outputted as ciinabox version.  Aside from binary version, vanity version number coming out of ciinabox config is rendered into template description as well. 

### Cli commands structure

Gem is not full replacement of Rake tasks, but mere wrapper around them. It improves usability by allowing user to run command from ciinaboxes directory, without the need to specify it explicitly through `CIINABOXES_DIR` variable or relying on default `ciinaboxes` dir.  Ciinabox name is always taken as last argument of cli command, with `install` and `full_install` commands being without ciinabox argument.

E.g. `ciinabox-ecs generate deploy update myciinabox` will result in following rake equiqalent
```
CIINABOXES_DIR=$PWD CIINABOX=myciinabox rake ciinabox:generate ciinabox:deploy ciinabox:update
``` 

Generic cli structure would be

`ciinabox-ecs action1 action2 .. actionN ciinabox_name`

Help can be obtained by running

`ciinabox-ecs help`

As for CIINABOXES_DIR and CIINABOX environment variables, they are still taken in account when running gem. In case CIINABOX environment variable is present, there is no need to specify ciinabox name as last argument, as it will be automatically assumed from environment. 

## Artifactory service

As work on artifactory service was done and tested in parallel with conversion to gem, this PR includes documentation and code for that service. 

