### PR TITLE
PIP Docker Version

### DIFF
--- a/ciinabox-ecs.gemspec
+++ b/ciinabox-ecs.gemspec
@@ -2,7 +2,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'ciinabox-ecs'
-  s.version = '0.2.11'
+  s.version = '0.2.12'
   s.version = "#{s.version}.alpha.#{Time.now.getutc.to_i}" if ENV['TRAVIS'] and ENV['TRAVIS_BRANCH'] != 'master'
   s.date = Date.today.to_s
   s.summary = 'Manage ciinabox on Aws Ecs'

--- a/lambdas/acm_issuer_validator/lib/install.sh
+++ b/lambdas/acm_issuer_validator/lib/install.sh
@@ -16,5 +16,5 @@ function pipinstall () {
 if [ $(which docker) == '' ]; then
     pipinstall
 else
-    docker run --rm -v $DIR/..:/dst -w /dst -u $UID python:3-alpine pip install aws-acm-cert-validator==0.1.11 -t lib
+    docker run --rm -v $DIR/..:/dst -w /dst -u $UID python:3.6-alpine pip install aws-acm-cert-validator==0.1.11 -t lib
 fi


### PR DESCRIPTION
Since python 3.7 has been released, pip install docker image needs to be fixed to 3.6