### PR TITLE
Increased vm.max_map_count as the default value caused issues with ES

### DIFF
--- a/templates/ecs-cluster.rb
+++ b/templates/ecs-cluster.rb
@@ -190,6 +190,8 @@ CloudFormation {
         "echo ECS_ENABLE_TASK_CPU_MEM_LIMIT=false >> /etc/ecs/ecs.config\n",
         "INSTANCE_ID=$(echo `/opt/aws/bin/ec2-metadata -i | cut -f2 -d:`)\n",
         "PRIVATE_IP=`/opt/aws/bin/ec2-metadata -o | cut -f2 -d: | cut -f2 -d-`\n",
+        "echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\n",
+        "sysctl -p\n",
         "hostname ciinabox-ecs-xx\n",
         "#{proxy_config_userdata}",
         "yum install -y python-pip\n",


### PR DESCRIPTION
A customer was having issues where ElasticSearch in the Sonarqube container wouldn't start because the vm.max_map_count sysctl was too low (~64k). Increasing it to 262144 fixed it.

https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

The only potential downsides I could find was programs _could_ use more memory.